### PR TITLE
Support iOS 11

### DIFF
--- a/Atlantis.xcodeproj/project.pbxproj
+++ b/Atlantis.xcodeproj/project.pbxproj
@@ -307,7 +307,7 @@
 					"SWIFT_PACKAGE=1",
 					"DEBUG=1",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -330,7 +330,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Atlantis.xcodeproj/Atlantis_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MARKETING_VERSION = 1.2.0;
@@ -359,7 +359,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Atlantis.xcodeproj/Atlantis_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MARKETING_VERSION = 1.2.0;
@@ -392,7 +392,7 @@
 					"$(inherited)",
 					"SWIFT_PACKAGE=1",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Atlantis",
     platforms: [.macOS(.v10_12),
-                .iOS(.v12)],
+                .iOS(.v11)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/atlantis-proxyman.podspec
+++ b/atlantis-proxyman.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |spec|
   spec.author             = { "Nghia Tran" => "nghia@proxyman.io" }
   spec.social_media_url   = "https://twitter.com/proxyman_app"
 
-  spec.ios.deployment_target = "12.0"
+  spec.ios.deployment_target = "11.0"
   spec.osx.deployment_target = "10.12"
   spec.module_name = "Atlantis"
 


### PR DESCRIPTION
### Description
Since NSNetService and URLSessionStreamTask have already supported from iOS 11+. We should support iOS 11 rather than iOS 12+

### Relationship
Ticket #30 

### Changelog
- Set minimum iOS 11
