### PR TITLE
fix bonjour services check

### DIFF
--- a/Sources/Atlantis.swift
+++ b/Sources/Atlantis.swift
@@ -274,7 +274,9 @@ extension Bundle {
 
     var hasBonjourServices: Bool {
         guard let services = Bundle.main.object(forInfoDictionaryKey: "NSBonjourServices") as? [String],
-              let proxymanService = services.first,
+              let proxymanService = services.first(where: {
+                    $0 == NetServiceTransport.Constants.netServiceType
+              }),
               proxymanService == NetServiceTransport.Constants.netServiceType else { return false }
         return true
     }


### PR DESCRIPTION
I have an app that uses Chromecast which already has two bonjour services. It took a while of debugging to figure out why Atlantis was giving an error on startup.

I changed from selecting the first bonjour service to the first one matching