### PR TITLE
Add Objective-C interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ You can get the `hostName` from Proxyman -> Certificate menu -> Install for iOS 
 
 <img src="https://raw.githubusercontent.com/ProxymanApp/atlantis/main/images/atlantis_hostname.png" alt="Proxyman screenshot" width="70%" height="auto"/>
 
+- If your project uses Objective-C
+
+```objective-c
+#import "Atlantis-Swift.h"
+
+// Add to the end of `application(_:didFinishLaunchingWithOptions:)` in AppDelegate
+[Atlantis startWithHostName:nil];
+```
+
 2. Make sure your iOS devices/simulator and macOS Proxyman are in the **same Wifi Network** or connect your iOS Devices to Mac by a **USB cable**
 3. Open macOS [Proxyman](https://proxyman.io) (or [download the lasted here](https://proxyman.io/release/osx/Proxyman_latest.dmg)) ([Github](https://github.com/ProxymanApp/Proxyman))(2.11.0+)
 4. Open your iOS app and Inspect traffic logs from Proxyman app

--- a/Sources/Atlantis.swift
+++ b/Sources/Atlantis.swift
@@ -70,7 +70,7 @@ public final class Atlantis: NSObject {
     /// If hostName is nil, Atlantis will find all Proxyman apps in the network. It's useful if we have only one machine for personal usage.
     /// If hostName is not nil, Atlantis will try to connect to particular mac machine. It's useful if you have multiple Proxyman.
     /// - Parameter hostName: Host name of Mac machine. You can find your current Host Name in Proxyman -> Certificate -> Install on iOS -> By Atlantis -> Show Start Atlantis
-    public class func start(hostName: String? = nil) {
+    @objc public class func start(hostName: String? = nil) {
         let configuration = Configuration.default(hostName: hostName)
 
         //
@@ -100,7 +100,7 @@ public final class Atlantis: NSObject {
     }
 
     /// Stop monitoring
-    public class func stop() {
+    @objc public class func stop() {
         guard isEnabled.value else { return }
         isEnabled.mutate { $0 = false }
         if Atlantis.shared.isEnabledTransportLayer {


### PR DESCRIPTION
I wanted to use Atlantis in my Objective-C based project. This change allows Atlantis to be used in Objective-C based projects and demonstrates how to use it with the Swift bridging header.