### PR TITLE
intercepting http(s) any app under jailbreak env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+theos/.theos
+theos/packages

--- a/theos/Makefile
+++ b/theos/Makefile
@@ -1,0 +1,24 @@
+ARCHS=arm64
+TARGET=iphone
+SDKVERSION=latest
+include $(THEOS)/makefiles/common.mk
+
+TWEAK_NAME = atlantis
+
+atlantis_FILES = Tweak.xm \
+	../Sources/Atlantis+Manual.swift \
+	../Sources/DispatchQueue+Once.swift \
+	../Sources/NetworkInjector.swift \
+	../Sources/Transporter.swift \
+	../Sources/Atlantis.swift \
+	../Sources/Message.swift \
+	../Sources/PackageIdentifier.swift \
+	../Sources/Configuration.swift \
+	../Sources/NetworkInjector+URLConnection.swift \
+	../Sources/Packages.swift \
+	../Sources/DataCompression.swift \
+	../Sources/NetworkInjector+URLSession.swift \
+	../Sources/Runtime.swift
+atlantis_CFLAGS = -fobjc-arc
+
+include $(THEOS_MAKE_PATH)/tweak.mk

--- a/theos/README.md
+++ b/theos/README.md
@@ -1,0 +1,12 @@
+# How to use
+
+1. Get [theos](https://github.com/theos/theos) installed
+2. cd theos
+3. make package
+4. scp deb file under packages to device and `dpkg -i` to install the deb file
+5. restart the target app
+
+Modify atlantis.plist, add bundle ID to any app you like to work with
+
+Modify Tweak.xm change HostName if you have multiple ProxyMan running on the same network
+

--- a/theos/Tweak.xm
+++ b/theos/Tweak.xm
@@ -1,0 +1,6 @@
+#import <atlantis-Swift.h>
+
+%ctor {
+    /** modify nil to hostName if you have multiple proxyman in same network **/
+    [Atlantis startWithHostName:nil];
+}

--- a/theos/atlantis.plist
+++ b/theos/atlantis.plist
@@ -1,0 +1,1 @@
+{ Filter = { Bundles = ( "your.app.bundle" ); }; }

--- a/theos/control
+++ b/theos/control
@@ -1,0 +1,9 @@
+Package: proxyman.atlantis
+Name: atlantis
+Depends: mobilesubstrate
+Version: 0.0.1
+Architecture: iphoneos-arm64
+Description: http(s) intercepting for proxyman
+Maintainer: atlantis
+Author: atlantis
+Section: Tweaks


### PR DESCRIPTION
Add theos build support, allows intercepting HTTP/HTTPS Traffic for any third party apps under jailbreak environment.