### PR TITLE
Fix warnings for depredated use of class for protocol inheritance

### DIFF
--- a/Sources/Atlantis.swift
+++ b/Sources/Atlantis.swift
@@ -9,7 +9,7 @@
 import Foundation
 import ObjectiveC
 
-public protocol AtlantisDelegate: class {
+public protocol AtlantisDelegate: AnyObject {
 
     func atlantisDidHaveNewPackage(_ package: TrafficPackage)
 }

--- a/Sources/NetworkInjector.swift
+++ b/Sources/NetworkInjector.swift
@@ -14,7 +14,7 @@ protocol Injector {
     func injectAllNetworkClasses()
 }
 
-protocol InjectorDelegate: class {
+protocol InjectorDelegate: AnyObject {
 
     // For URLSession
     func injectorSessionDidCallResume(task: URLSessionTask)


### PR DESCRIPTION
We were seeing warnings on these two lines in our xcodebuild output using Xcode 12.5

> using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead