### PR TITLE
Fix "Invalid Exclude" warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,13 +20,11 @@ let package = Package(
         .target(
             name: "Atlantis-Objc",
             path: "Objc",
-            exclude: ["Sources"],
             publicHeadersPath: "internal"),
         .target(
             name: "Atlantis",
             dependencies: ["Atlantis-Objc"],
-            path: "Sources",
-            exclude: ["Atlantis-Example", "Configs", "Images", "Tests"])
+            path: "Sources")
     ],
     swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
My understanding is that these exclude specs are not needed. They are outside of the specified `path` so were never considered for inclusion.

Here is a screenshot of the warnings we are getting using Xcode 13 beta 2.

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/78082/124013128-2c3aa380-d99f-11eb-84f1-447d3d1a8d37.png">
