### PR TITLE
Atlantis with Swift Playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,26 @@ func insertNote(note: Note, completion: @escaping(Note?, CallResult?) -> Void) {
 }
 ```
 
+#### 3. Use Atlantis on Swift Playground
+Atlantis is capable of capturing the HTTP/HTTPS and WS/WSS traffic from your Swift Playground.
+
+1. Use [Arena](https://github.com/finestructure/Arena) to generate a new Swift Playground with Atlantis. If you would like to add Atlantis to your existing Swift Playground, please follow [this tutorial](https://wwdcbysundell.com/2020/importing-swift-packages-into-a-playground-in-xcode12/).
+2. Enable Swift Playground Mode
+```swift
+Atlantis.setIsRunningOniOSPlayground(true)
+Atlantis.start()
+```
+
+3. Trust Proxyman self-signed certificate
+
+- for macOS: You don't need to do anything if you've already installed & trusted Proxyman Certificate in Certificate Menu -> Install on this Mac.
+- for iOS: Since iOS Playground doesn't start any iOS Simulator, it's impossible to inject the Proxyman Certificate. Therefore, we have to manually trust the certificate. Please use [NetworkSSLProxying](https://gist.github.com/NghiaTranUIT/275c8da5068d506869a21bd16da27094) class to do it.
+
+4. Make an HTTP/HTTPS or WS/WSS and inspect it on the Proxyman app.
+
+- Sample Code: https://github.com/ProxymanApp/Atlantis-Swift-Playground-Sample-App
+
+
 ## FAQ
 #### 1. How does Atlantis work?
 

--- a/Sources/Atlantis.swift
+++ b/Sources/Atlantis.swift
@@ -150,15 +150,15 @@ extension Atlantis {
             print("---------------------------------------------------------------------------------")
         }
 
-        // For iOS
-        #if os(iOS)
-
         // Don't need to check configs on Info.plist
         if Atlantis.shared.isRunningOniOSPlayground {
-            print("---------- Running on iOS Swift Playground Mode")
+            print("---------- Running on Swift Playground Mode")
             print("If you get the SSL Error, please follow this code: https://gist.github.com/NghiaTranUIT/275c8da5068d506869a21bd16da27094")
             return
         }
+
+        // For iOS
+        #if os(iOS)
 
         // Check required config for Local Network in the main app's info.plist
         // Ref: https://developer.apple.com/news/?id=0oi77447

--- a/Sources/Atlantis.swift
+++ b/Sources/Atlantis.swift
@@ -35,10 +35,15 @@ public final class Atlantis: NSObject {
 
     /// Check whether or not Bonjour Service is available in current devices
     private static var isServiceAvailable: Bool = {
-        return true
-        
-        // Require extra config for iOS 14
+
         #if os(iOS)
+
+        // on iOS Swift Playgroud, no need to add configs to Info.plist
+        if Atlantis.shared.isRunningOniOSPlayground {
+            return true
+        }
+
+        // Require extra config for iOS 14
         if #available(iOS 14, *) {
             return Bundle.main.hasBonjourServices && Bundle.main.hasLocalNetworkUsageDescription
         }
@@ -54,6 +59,10 @@ public final class Atlantis: NSObject {
     /// Determine whether or not the transport layer (e.g. Bonjour service) is enabled
     /// If it's enabled, it will send the traffic to Proxyman macOS app
     private var isEnabledTransportLayer = true
+
+    /// Determine if Atlantis is running on Swift Playground
+    /// If it's enabled, Atlantis will bypass some safety checks
+    private var isRunningOniOSPlayground = false
 
     // MARK: - Init
 
@@ -118,6 +127,11 @@ public final class Atlantis: NSObject {
         Atlantis.shared.isEnabledTransportLayer = isEnabled
     }
 
+    /// Enable Swift Playground mode
+    public class func setIsRunningOniOSPlayground(_ isEnabled: Bool) {
+        Atlantis.shared.isRunningOniOSPlayground = isEnabled
+    }
+
     /// Set delegate to observe the traffic
     public class func setDelegate(_ delegate: AtlantisDelegate) {
         Atlantis.shared.delegate = delegate
@@ -136,10 +150,19 @@ extension Atlantis {
             print("---------------------------------------------------------------------------------")
         }
 
+        // For iOS
+        #if os(iOS)
+
+        // Don't need to check configs on Info.plist
+        if Atlantis.shared.isRunningOniOSPlayground {
+            print("---------- Running on iOS Swift Playground Mode")
+            print("If you get the SSL Error, please follow this code: https://gist.github.com/NghiaTranUIT/275c8da5068d506869a21bd16da27094")
+            return
+        }
+
         // Check required config for Local Network in the main app's info.plist
         // Ref: https://developer.apple.com/news/?id=0oi77447
         // Only for iOS 14
-        #if os(iOS)
         if #available(iOS 14, *) {
             var instruction: [String] = []
             if !Bundle.main.hasLocalNetworkUsageDescription {

--- a/Sources/Atlantis.swift
+++ b/Sources/Atlantis.swift
@@ -35,6 +35,8 @@ public final class Atlantis: NSObject {
 
     /// Check whether or not Bonjour Service is available in current devices
     private static var isServiceAvailable: Bool = {
+        return true
+        
         // Require extra config for iOS 14
         #if os(iOS)
         if #available(iOS 14, *) {


### PR DESCRIPTION
### Changelog
- Add `isRunningOniOSPlayground` to bypass the Safety check for the Bonjour Service
- Able to integrate Atlantis to Swift Playground (iOS and macOS)