### PR TITLE
Fix crash when download large file

### DIFF
--- a/Sources/Packages.swift
+++ b/Sources/Packages.swift
@@ -143,7 +143,7 @@ public final class TrafficPackage: Codable, CustomDebugStringConvertible, Serial
         // Construct the Response without body
         self.response = Response(response)
     }
-    
+
     func updateDidComplete(_ error: Error?) {
         endAt = Date().timeIntervalSince1970
         if let error = error {
@@ -170,6 +170,12 @@ public final class TrafficPackage: Codable, CustomDebugStringConvertible, Serial
             return
         }
         lastData = data
+
+        // Avoid memory consumes in app when download large file that causing crash app
+        guard responseBodyData.count < NetServiceTransport.MaximumSizeResponse else {
+          endAt = Date().timeIntervalSince1970
+          return
+        }
         responseBodyData.append(data)
     }
 

--- a/Sources/Transporter.swift
+++ b/Sources/Transporter.swift
@@ -48,7 +48,7 @@ final class NetServiceTransport: NSObject {
     // For some reason, Stream Task could send a big file
     // https://github.com/ProxymanApp/atlantis/issues/57
     static let MaximumSizePackage = 52428800 // 50Mb
-    static let MaximumSizeResponse = 2097152 // 2MB
+    static let MaximumSizeResponse = 10485760 // 10MB
     private let serviceBrowser: NetServiceBrowser
     private var services: [NetService] = []
     private let queue = DispatchQueue(label: "com.proxyman.atlantis.netservices") // Serial on purpose

--- a/Sources/Transporter.swift
+++ b/Sources/Transporter.swift
@@ -48,7 +48,7 @@ final class NetServiceTransport: NSObject {
     // For some reason, Stream Task could send a big file
     // https://github.com/ProxymanApp/atlantis/issues/57
     static let MaximumSizePackage = 52428800 // 50Mb
-
+    static let MaximumSizeResponse = 2097152 // 2MB
     private let serviceBrowser: NetServiceBrowser
     private var services: [NetService] = []
     private let queue = DispatchQueue(label: "com.proxyman.atlantis.netservices") // Serial on purpose


### PR DESCRIPTION
Avoid memory consuming in app when download large file that causing crash app
<img width="468" alt="Screen Shot 2022-03-25 at 18 56 48" src="https://user-images.githubusercontent.com/12556134/160116567-e10b2182-c592-4913-af8b-5109c57df56a.png">
<img width="918" alt="Screen Shot 2022-03-25 at 19 05 11" src="https://user-images.githubusercontent.com/12556134/160117830-a7672832-b82a-4fdc-8aa6-cd44269e8c13.png">
<img width="1679" alt="Screen Shot 2022-03-25 at 19 06 07" src="https://user-images.githubusercontent.com/12556134/160117835-c6839084-13bf-4a97-b923-b9f2326a3df2.png">

