### PR TITLE
atlantis on projects with ios below 13.0

### DIFF
--- a/Sources/Atlantis+Manual.swift
+++ b/Sources/Atlantis+Manual.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension Atlantis {
 
     /// Handy func to manually add Request & Response to Atlantis, then sending to Proxyman app for inspecting.
@@ -185,6 +186,7 @@ extension Atlantis {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension WebsocketMessagePackage.Message {
     var optionalData: Data? {
         switch self {

--- a/Sources/Atlantis.swift
+++ b/Sources/Atlantis.swift
@@ -9,6 +9,7 @@
 import Foundation
 import ObjectiveC
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public protocol AtlantisDelegate: AnyObject {
 
     func atlantisDidHaveNewPackage(_ package: TrafficPackage)
@@ -17,6 +18,7 @@ public protocol AtlantisDelegate: AnyObject {
 /// The main class of Atlantis
 /// Responsible to swizzle certain functions from URLSession
 /// to capture the network and send to Proxyman app via Bonjour Service
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public final class Atlantis: NSObject {
 
     static let shared = Atlantis()
@@ -140,6 +142,7 @@ public final class Atlantis: NSObject {
 
 // MARK: - Private
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension Atlantis {
 
     private func safetyCheck() {
@@ -225,6 +228,7 @@ extension Atlantis {
 
 // MARK: - Injection Methods
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension Atlantis: InjectorDelegate {
 
     func injectorSessionDidCallResume(task: URLSessionTask) {
@@ -278,6 +282,7 @@ extension Atlantis: InjectorDelegate {
 
 // MARK: - Websocket
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension Atlantis {
 
     func injectorSessionWebSocketDidSendPingPong(task: URLSessionTask) {
@@ -348,6 +353,7 @@ extension Atlantis {
 
 // MARK: - Private
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension Atlantis {
 
     private func handleDidFinish(_ taskOrConnection: AnyObject, error: Error?) {

--- a/Sources/Message.swift
+++ b/Sources/Message.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 struct Message: Codable {
 
     enum MessageType: String, Codable {
@@ -49,6 +50,7 @@ struct Message: Codable {
 
 // MARK: - Serializable
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension Message: Serializable {
 
     func toData() -> Data? {

--- a/Sources/NetworkInjector+URLSession.swift
+++ b/Sources/NetworkInjector+URLSession.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension NetworkInjector {
 
     func _swizzleURLSessionResumeSelector(baseClass: AnyClass) {
@@ -179,6 +180,7 @@ extension NetworkInjector {
 
 // MARK: - Upload
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension NetworkInjector {
 
     func _swizzleURLSessionUploadSelector(baseClass: AnyClass) {
@@ -324,6 +326,7 @@ extension NetworkInjector {
 
 // MARK: - WebSocket
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension NetworkInjector {
 
     func _swizzleURLSessionWebsocketSelector() {

--- a/Sources/NetworkInjector.swift
+++ b/Sources/NetworkInjector.swift
@@ -8,12 +8,14 @@
 
 import Foundation
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 protocol Injector {
 
     var delegate: InjectorDelegate? { get set }
     func injectAllNetworkClasses()
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 protocol InjectorDelegate: AnyObject {
 
     // For URLSession
@@ -30,6 +32,7 @@ protocol InjectorDelegate: AnyObject {
     func injectorSessionWebSocketDidSendCancelWithReason(task: URLSessionTask, closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?)
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 final class NetworkInjector: Injector {
 
     // MARK: - Variables
@@ -46,6 +49,7 @@ final class NetworkInjector: Injector {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension NetworkInjector {
 
     private func injectAllURLSession() {

--- a/Sources/Packages.swift
+++ b/Sources/Packages.swift
@@ -42,6 +42,7 @@ struct ConnectionPackage: Codable, Serializable {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public final class TrafficPackage: Codable, CustomDebugStringConvertible, Serializable {
 
     public enum PackageType: String, Codable {
@@ -327,6 +328,7 @@ public struct CustomError: Codable {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 public struct WebsocketMessagePackage: Codable, Serializable {
 
     public enum MessageType: String, Codable {

--- a/Sources/Transporter.swift
+++ b/Sources/Transporter.swift
@@ -87,6 +87,7 @@ final class NetServiceTransport: NSObject {
 
 // MARK: - Transporter
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension NetServiceTransport: Transporter {
 
     func start(_ config: Configuration) {
@@ -195,6 +196,7 @@ extension NetServiceTransport: Transporter {
 
 // MARK: - Private
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension NetServiceTransport {
 
     private func connectToService(_ service: NetService) {
@@ -294,6 +296,7 @@ extension NetServiceTransport {
 
 // MARK: - NetServiceBrowserDelegate
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension NetServiceTransport: NetServiceBrowserDelegate {
 
     func netServiceBrowser(_ browser: NetServiceBrowser, didFind service: NetService, moreComing: Bool) {
@@ -330,6 +333,7 @@ extension NetServiceTransport: NetServiceBrowserDelegate {
 
 // MARK: - NetServiceDelegate
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension NetServiceTransport: NetServiceDelegate {
 
     func netServiceDidResolveAddress(_ sender: NetService) {


### PR DESCRIPTION
this will let atlantis be used on projects with a minimum requirement of ios below 13.0

if project minimum ios are below 13.0
```swift
import Atlantis

if #available(iOS 13.0, *) {
   Atlantis.start()
}
```

for project with minimum ios  13.0 or more
```swift
import Atlantis
Atlantis.start()
```