### PR TITLE
fix memory leak of `class_copyMethodList`

### DIFF
--- a/Sources/Runtime.swift
+++ b/Sources/Runtime.swift
@@ -37,6 +37,7 @@ struct Runtime {
             let name = String(cString: selName)
             methods.append(name)
         }
+        methodList?.deallocate()
         return methods
     }
 }


### PR DESCRIPTION
Should free the return value of `class_copyMethodList `