### PR TITLE
feat: Add visionOS support

### DIFF
--- a/Sources/Packages.swift
+++ b/Sources/Packages.swift
@@ -11,7 +11,7 @@ import Foundation
 #if os(OSX)
 import AppKit
 typealias Image = NSImage
-#elseif os(iOS) || targetEnvironment(macCatalyst)  || os(tvOS)
+#elseif os(iOS) || targetEnvironment(macCatalyst)  || os(tvOS) || os(visionOS)
 import UIKit
 typealias Image = UIImage
 #endif
@@ -214,7 +214,7 @@ struct Device: Codable {
         let macName = Host.current().name ?? "Unknown Mac Devices"
         name = macName
         model = "\(macName) \(ProcessInfo.processInfo.operatingSystemVersionString)"
-        #elseif os(iOS) || targetEnvironment(macCatalyst) || os(tvOS)
+        #elseif os(iOS) || targetEnvironment(macCatalyst) || os(tvOS) || os(visionOS)
         let device = UIDevice.current
         name = device.name
         model = "\(device.name) (\(device.systemName) \(device.systemVersion))"
@@ -410,7 +410,7 @@ extension Image {
             return nil
         }
         return Image(named: iconName)
-        #elseif os(iOS) || os(tvOS)
+        #elseif os(iOS) || os(tvOS) || os(visionOS)
         guard let iconsDictionary = Bundle.main.infoDictionary?["CFBundleIcons"] as? [String: Any],
               let primaryIconsDictionary = iconsDictionary["CFBundlePrimaryIcon"] as? [String: Any],
               let iconFiles = primaryIconsDictionary["CFBundleIconFiles"] as? [String],
@@ -426,7 +426,7 @@ extension Image {
         // Resize, we don't need 1024px size
         newRep.size = CGSize(width: 64, height: 64)
         return newRep.representation(using: .png, properties: [:])
-        #elseif os(iOS) || targetEnvironment(macCatalyst) || os(tvOS)
+        #elseif os(iOS) || targetEnvironment(macCatalyst) || os(tvOS) || os(visionOS)
         // It's already by 64px
         return self.pngData()
         #endif


### PR DESCRIPTION
This PR adds support for visionOS in Atlantis. As of now, Atlantis builds fail for visionOS.