### PR TITLE
Fix AVAggregateAssetDownloadTask crash

### DIFF
--- a/Sources/Packages.swift
+++ b/Sources/Packages.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Proxyman. All rights reserved.
 //
 
+import class AVFoundation.AVAggregateAssetDownloadTask
 import Foundation
 
 #if os(OSX)
@@ -101,6 +102,13 @@ public final class TrafficPackage: Codable, CustomDebugStringConvertible, Serial
     // MARK: - Builder
 
     static func buildRequest(sessionTask: URLSessionTask, id: String) -> TrafficPackage? {
+        // If sessionTask is AVAggregateAssetDownloadTask,
+        // accessing currentRequest crashes with not supported error,
+        // so we need to check for it in advance.
+        if sessionTask is AVAggregateAssetDownloadTask {
+            return nil
+        }
+
         guard let currentRequest = sessionTask.currentRequest,
             let request = Request(currentRequest) else { return nil }
 


### PR DESCRIPTION
When `AVAggregateAssetDownloadTask` is started, Atlantis crashes running app, because it checks `currentRequest` property which is not supported. 

Thrown exception explicitly states:
> AVAggregateAssetDownloadTask does not support currentRequest property

As skipping is definitely better option to crashing, this PR skips tracking this type of tasks.