### PR TITLE
Make sure all accesses to `URLSessionTask.currentRequest` are crash safe

### DIFF
--- a/Sources/Atlantis.swift
+++ b/Sources/Atlantis.swift
@@ -253,7 +253,7 @@ extension Atlantis {
         // If not found, just generate and cache
         switch taskOrConnection {
         case let task as URLSessionTask:
-            guard let request = task.currentRequest,
+            guard let request = task.currentRequestSafe,
                   let package = TrafficPackage.buildRequest(sessionTask: task, id: id) else {
                 print("[Atlantis] ❌ Error: Should build package from URLSessionTask")
                 return nil

--- a/Sources/Packages.swift
+++ b/Sources/Packages.swift
@@ -6,10 +6,6 @@
 //  Copyright © 2020 Proxyman. All rights reserved.
 //
 
-#if os(iOS) || os(macOS)
-import class AVFoundation.AVAggregateAssetDownloadTask
-#endif
-
 import Foundation
 
 #if os(OSX)
@@ -105,17 +101,8 @@ public final class TrafficPackage: Codable, CustomDebugStringConvertible, Serial
     // MARK: - Builder
 
     static func buildRequest(sessionTask: URLSessionTask, id: String) -> TrafficPackage? {
-        // If sessionTask is AVAggregateAssetDownloadTask,
-        // accessing currentRequest crashes with not supported error,
-        // so we need to check for it in advance.
-        #if os(iOS) || os(macOS)
-        if sessionTask is AVAggregateAssetDownloadTask {
-            return nil
-        }
-        #endif
-
-        guard let currentRequest = sessionTask.currentRequest,
-            let request = Request(currentRequest) else { return nil }
+        guard let currentRequest = sessionTask.currentRequestSafe,
+              let request = Request(currentRequest) else { return nil }
 
         // Check if it's a websocket
         if let websocketClass = NSClassFromString("__NSURLSessionWebSocketTask"),

--- a/Sources/URLSessionTask+CurrentRequest.swift
+++ b/Sources/URLSessionTask+CurrentRequest.swift
@@ -1,0 +1,20 @@
+
+import Foundation
+#if os(iOS) || os(macOS)
+import class AVFoundation.AVAggregateAssetDownloadTask
+#endif
+
+extension URLSessionTask {
+    var currentRequestSafe: URLRequest? {
+        // If sessionTask is AVAggregateAssetDownloadTask,
+        // accessing currentRequest crashes with not supported error,
+        // so we need to check for it in advance.
+        #if os(iOS) || os(macOS)
+        if self is AVAggregateAssetDownloadTask {
+            return nil
+        }
+        #endif
+
+        return currentRequest
+    }
+}


### PR DESCRIPTION
This was already fixed in https://github.com/ProxymanApp/atlantis/pull/151 but unfortunately reintroduced by another call to `.currentRequest` in https://github.com/ProxymanApp/atlantis/commit/b9542919ae59dbecff5374c52c40cb62d2f57164

This PR adds a new extension to move the access check to a shared location