### PR TITLE
Skip .icns assets when running macOS Catalyst

### DIFF
--- a/Sources/Packages.swift
+++ b/Sources/Packages.swift
@@ -485,6 +485,9 @@ extension Image {
         guard let iconName = Bundle.main.infoDictionary?["CFBundleIconFile"] as? String else {
             return nil
         }
+        if let _ = Bundle.main.url(forResource: iconName, withExtension: "icns") {
+            return nil
+        }
         return Image(named: iconName)
         #elseif os(iOS) || os(tvOS) || os(visionOS)
         if let iconsDictionary = Bundle.main.infoDictionary?["CFBundleIcons"] as? [String: Any],


### PR DESCRIPTION
Hello, we've encountered a crash during icon loading when running on a macOS Catalyst target with Proxyman active. I've found that .icon assets for Liquid Glass get converted to .icns in bundle on Catalyst. But that can only be loaded with NSImage, not Image. So I added an early-exit guard in the macCatalyst branch of the app icon resolution logic in Packages.swift.