### PR TITLE
Add SSE capture tests and streaming demo support

### DIFF
--- a/Example/AtlantisSwiftUIApp/AtlantisSwiftUIApp/ContentView.swift
+++ b/Example/AtlantisSwiftUIApp/AtlantisSwiftUIApp/ContentView.swift
@@ -9,11 +9,31 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var responseText = ""
+
+    // Server-Sent Events state
+    @State private var sseTask: URLSessionDataTask?
+    @State private var sseSession: URLSession?
+    @State private var sseDelegate: SSEStreamDelegate?
+    @State private var sseStatus = "Disconnected"
+    @State private var sseMessages: [String] = []
+    @State private var sseBuffer = ""
+    @State private var sseStreamID = UUID()
     
     // WebSocket state
     @State private var webSocketTask: URLSessionWebSocketTask?
     @State private var webSocketStatus = "Disconnected"
     @State private var webSocketMessages: [String] = []
+
+    private var sseStatusColor: Color {
+        switch sseStatus {
+        case "Connected":
+            return .green
+        case "Connecting":
+            return .orange
+        default:
+            return .red
+        }
+    }
     
     var body: some View {
         VStack {
@@ -62,6 +82,33 @@ struct ContentView: View {
                     
                     Divider()
                         .padding(.vertical, 8)
+
+                    VStack {
+                        Text("Server-Sent Events Test")
+                            .font(.headline)
+                            .padding(.bottom, 4)
+
+                        Text("Status: \(sseStatus)")
+                            .font(.caption)
+                            .foregroundColor(sseStatusColor)
+
+                        HStack {
+                            Button(sseStatus == "Disconnected" ? "Start SSE Demo" : "Restart SSE Demo") {
+                                startSSETest()
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(sseStatus == "Connecting")
+
+                            Button("Stop SSE Demo") {
+                                stopSSETest()
+                            }
+                            .buttonStyle(.bordered)
+                            .disabled(sseTask == nil)
+                        }
+                    }
+
+                    Divider()
+                        .padding(.vertical, 8)
                     
                     VStack {
                         Text("WebSocket Test")
@@ -84,7 +131,7 @@ struct ContentView: View {
                 
                 Divider()
                 
-                if responseText.isEmpty && webSocketMessages.isEmpty {
+                if responseText.isEmpty && sseMessages.isEmpty && webSocketMessages.isEmpty {
                     Text("Response will appear here")
                         .foregroundColor(.gray)
                         .padding()
@@ -96,6 +143,17 @@ struct ContentView: View {
                             Text(responseText)
                                 .font(.system(.body, design: .monospaced))
                                 .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+
+                        if !sseMessages.isEmpty {
+                            Text("SSE Events:")
+                                .font(.headline)
+                            ForEach(Array(sseMessages.enumerated()), id: \.offset) { index, message in
+                                Text(message)
+                                    .font(.system(.caption, design: .monospaced))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.vertical, 2)
+                            }
                         }
                         
                         if !webSocketMessages.isEmpty {
@@ -112,6 +170,9 @@ struct ContentView: View {
                     .padding()
                 }
             }
+        }
+        .onDisappear {
+            stopSSETest(shouldAddMessage: false)
         }
     }
     
@@ -234,6 +295,208 @@ struct ContentView: View {
             }
         }.resume()
     }
+
+    // MARK: - Server-Sent Events Methods
+
+    func startSSETest() {
+        stopSSETest(shouldAddMessage: false)
+
+        sseMessages.removeAll()
+        sseBuffer = ""
+        responseText = ""
+
+        guard let url = URL(string: "https://stream.wikimedia.org/v2/stream/recentchange") else {
+            addSSEMessage("Invalid SSE URL")
+            return
+        }
+
+        let streamID = UUID()
+        sseStreamID = streamID
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.setValue("AtlantisSwiftUIApp/1.0 (https://github.com/ProxymanApp/atlantis)", forHTTPHeaderField: "User-Agent")
+
+        let delegate = SSEStreamDelegate()
+        delegate.onResponse = { response in
+            DispatchQueue.main.async {
+                guard self.sseStreamID == streamID else { return }
+                self.sseStatus = "Connected"
+                self.addSSEMessage("Connected (HTTP \(response.statusCode))")
+            }
+        }
+        delegate.onData = { data in
+            DispatchQueue.main.async {
+                guard self.sseStreamID == streamID else { return }
+                self.handleSSEData(data)
+            }
+        }
+        delegate.onComplete = { error in
+            DispatchQueue.main.async {
+                guard self.sseStreamID == streamID else { return }
+                self.handleSSECompletion(error)
+            }
+        }
+
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 60
+        configuration.timeoutIntervalForResource = 15 * 60
+
+        let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+        let task = session.dataTask(with: request)
+
+        sseDelegate = delegate
+        sseSession = session
+        sseTask = task
+        sseStatus = "Connecting"
+        addSSEMessage("Connecting to Wikimedia EventStreams...")
+
+        task.resume()
+    }
+
+    private func stopSSETest(shouldAddMessage: Bool = true) {
+        guard sseTask != nil || sseSession != nil else { return }
+
+        if shouldAddMessage {
+            addSSEMessage("Stopping SSE stream...")
+        }
+
+        sseTask?.cancel()
+        sseSession?.invalidateAndCancel()
+        sseTask = nil
+        sseSession = nil
+        sseDelegate = nil
+        sseStreamID = UUID()
+        sseStatus = "Disconnected"
+    }
+
+    private func handleSSEData(_ data: Data) {
+        guard let chunk = String(data: data, encoding: .utf8) else {
+            addSSEMessage("Received \(data.count) SSE bytes")
+            return
+        }
+
+        // SSE events are separated by a blank line, but chunks can split an event anywhere.
+        sseBuffer += chunk
+        sseBuffer = sseBuffer.replacingOccurrences(of: "\r\n", with: "\n")
+
+        let parts = sseBuffer.components(separatedBy: "\n\n")
+        guard parts.count > 1 else { return }
+
+        sseBuffer = parts.last ?? ""
+        for event in parts.dropLast() {
+            let trimmedEvent = event.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedEvent.isEmpty else { continue }
+            addSSEMessage(summarizeSSEEvent(trimmedEvent))
+        }
+    }
+
+    private func handleSSECompletion(_ error: Error?) {
+        let nsError = error as NSError?
+        if nsError?.domain == NSURLErrorDomain && nsError?.code == NSURLErrorCancelled {
+            sseStatus = "Disconnected"
+            return
+        }
+
+        if let error = error {
+            addSSEMessage("SSE error: \(error.localizedDescription)")
+        } else {
+            addSSEMessage("SSE stream completed")
+        }
+
+        sseTask = nil
+        sseSession = nil
+        sseDelegate = nil
+        sseStatus = "Disconnected"
+    }
+
+    private func summarizeSSEEvent(_ eventText: String) -> String {
+        var eventName: String?
+        var eventID: String?
+        var dataLines: [String] = []
+        var comment: String?
+        var retry: String?
+
+        for rawLine in eventText.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(rawLine)
+            if line.hasPrefix(":") {
+                comment = String(line.dropFirst()).trimmingCharacters(in: .whitespaces)
+                continue
+            }
+
+            let parts = line.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+            let field = parts.first.map(String.init) ?? ""
+            var value = parts.count > 1 ? String(parts[1]) : ""
+            if value.hasPrefix(" ") {
+                value.removeFirst()
+            }
+
+            switch field {
+            case "event":
+                eventName = value
+            case "id":
+                eventID = value
+            case "data":
+                dataLines.append(value)
+            case "retry":
+                retry = value
+            default:
+                break
+            }
+        }
+
+        if !dataLines.isEmpty {
+            return summarizeSSEData(dataLines.joined(separator: "\n"), eventName: eventName, eventID: eventID)
+        }
+
+        if let comment = comment, !comment.isEmpty {
+            return "comment: \(truncate(comment, maxLength: 180))"
+        }
+
+        if let retry = retry, !retry.isEmpty {
+            return "retry: \(retry) ms"
+        }
+
+        return truncate(eventText, maxLength: 180)
+    }
+
+    private func summarizeSSEData(_ dataText: String, eventName: String?, eventID: String?) -> String {
+        let label = eventName ?? "message"
+        var details = truncate(dataText, maxLength: 180)
+
+        if let data = dataText.data(using: .utf8),
+           let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] {
+            let wiki = object["wiki"] as? String ?? object["server_name"] as? String
+            let title = object["title"] as? String
+            let user = object["user"] as? String
+            let readableFields = [wiki, title, user].compactMap { $0 }.filter { !$0.isEmpty }
+            if !readableFields.isEmpty {
+                details = readableFields.joined(separator: " | ")
+            }
+        }
+
+        if let eventID = eventID, !eventID.isEmpty {
+            return "event: \(label)\nid: \(truncate(eventID, maxLength: 80))\n\(details)"
+        }
+
+        return "event: \(label)\n\(details)"
+    }
+
+    private func addSSEMessage(_ message: String) {
+        let timestamp = DateFormatter.timeFormatter.string(from: Date())
+        sseMessages.append("[\(timestamp)] \(message)")
+
+        // Keep the demo lightweight while the stream stays open.
+        if sseMessages.count > 20 {
+            sseMessages.removeFirst()
+        }
+    }
+
+    private func truncate(_ text: String, maxLength: Int) -> String {
+        guard text.count > maxLength else { return text }
+        return String(text.prefix(maxLength)) + "..."
+    }
     
     // MARK: - WebSocket Methods
     
@@ -272,7 +535,7 @@ struct ContentView: View {
     }
     
     private func checkConnectionAndStartDemo() {
-        guard let task = webSocketTask else { return }
+        guard webSocketTask != nil else { return }
         
         self.webSocketStatus = "Connected"
         self.addWebSocketMessage("✅ WebSocket connected successfully!")
@@ -476,6 +739,36 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+}
+
+// MARK: - SSE URLSession Delegate
+
+private final class SSEStreamDelegate: NSObject, URLSessionDataDelegate {
+    var onResponse: ((HTTPURLResponse) -> Void)?
+    var onData: ((Data) -> Void)?
+    var onComplete: ((Error?) -> Void)?
+
+    func urlSession(_ session: URLSession,
+                    dataTask: URLSessionDataTask,
+                    didReceive response: URLResponse,
+                    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        if let response = response as? HTTPURLResponse {
+            onResponse?(response)
+        }
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession,
+                    dataTask: URLSessionDataTask,
+                    didReceive data: Data) {
+        onData?(data)
+    }
+
+    func urlSession(_ session: URLSession,
+                    task: URLSessionTask,
+                    didCompleteWithError error: Error?) {
+        onComplete?(error)
+    }
 }
 
 // MARK: - Extensions

--- a/Example/AtlantisSwiftUIApp/AtlantisSwiftUIApp/ContentView.swift
+++ b/Example/AtlantisSwiftUIApp/AtlantisSwiftUIApp/ContentView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Network
 
 struct ContentView: View {
     @State private var responseText = ""
@@ -17,7 +18,11 @@ struct ContentView: View {
     @State private var sseStatus = "Disconnected"
     @State private var sseMessages: [String] = []
     @State private var sseBuffer = ""
+    @State private var sseEventCount = 0
+    @State private var sseDemoServer: LocalSSEDemoServer?
     @State private var sseStreamID = UUID()
+    private let sseDemoMaxEvents = 10
+    private let sseDemoEventInterval: TimeInterval = 0.5
     
     // WebSocket state
     @State private var webSocketTask: URLSessionWebSocketTask?
@@ -303,16 +308,41 @@ struct ContentView: View {
 
         sseMessages.removeAll()
         sseBuffer = ""
+        sseEventCount = 0
         responseText = ""
-
-        guard let url = URL(string: "https://stream.wikimedia.org/v2/stream/recentchange") else {
-            addSSEMessage("Invalid SSE URL")
-            return
-        }
 
         let streamID = UUID()
         sseStreamID = streamID
+        sseStatus = "Connecting"
+        addSSEMessage("Starting local SSE demo server...")
 
+        do {
+            let server = try LocalSSEDemoServer(maxEvents: sseDemoMaxEvents,
+                                                eventInterval: sseDemoEventInterval)
+            server.onReady = { url in
+                DispatchQueue.main.async {
+                    guard self.sseStreamID == streamID else { return }
+                    self.addSSEMessage("Local SSE server ready")
+                    self.startSSERequest(url: url, streamID: streamID)
+                }
+            }
+            server.onError = { error in
+                DispatchQueue.main.async {
+                    guard self.sseStreamID == streamID else { return }
+                    self.addSSEMessage("SSE server error: \(error.localizedDescription)")
+                    self.stopSSETest(shouldAddMessage: false)
+                }
+            }
+
+            sseDemoServer = server
+            server.start()
+        } catch {
+            addSSEMessage("Failed to start SSE demo server: \(error.localizedDescription)")
+            sseStatus = "Disconnected"
+        }
+    }
+
+    private func startSSERequest(url: URL, streamID: UUID) {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
@@ -323,7 +353,7 @@ struct ContentView: View {
             DispatchQueue.main.async {
                 guard self.sseStreamID == streamID else { return }
                 self.sseStatus = "Connected"
-                self.addSSEMessage("Connected (HTTP \(response.statusCode))")
+                self.addSSEMessage("Connected (HTTP \(response.statusCode)); expecting 10 events")
             }
         }
         delegate.onData = { data in
@@ -349,14 +379,13 @@ struct ContentView: View {
         sseDelegate = delegate
         sseSession = session
         sseTask = task
-        sseStatus = "Connecting"
-        addSSEMessage("Connecting to Wikimedia EventStreams...")
+        addSSEMessage("Connecting to \(url.absoluteString)")
 
         task.resume()
     }
 
     private func stopSSETest(shouldAddMessage: Bool = true) {
-        guard sseTask != nil || sseSession != nil else { return }
+        guard sseTask != nil || sseSession != nil || sseDemoServer != nil else { return }
 
         if shouldAddMessage {
             addSSEMessage("Stopping SSE stream...")
@@ -364,9 +393,11 @@ struct ContentView: View {
 
         sseTask?.cancel()
         sseSession?.invalidateAndCancel()
+        sseDemoServer?.stop()
         sseTask = nil
         sseSession = nil
         sseDelegate = nil
+        sseDemoServer = nil
         sseStreamID = UUID()
         sseStatus = "Disconnected"
     }
@@ -388,7 +419,16 @@ struct ContentView: View {
         for event in parts.dropLast() {
             let trimmedEvent = event.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmedEvent.isEmpty else { continue }
-            addSSEMessage(summarizeSSEEvent(trimmedEvent))
+            guard sseEventCount < sseDemoMaxEvents else { continue }
+
+            sseEventCount += 1
+            addSSEMessage("Event \(sseEventCount)/\(sseDemoMaxEvents)\n\(summarizeSSEEvent(trimmedEvent))")
+
+            if sseEventCount >= sseDemoMaxEvents {
+                addSSEMessage("SSE demo completed; stopping stream")
+                stopSSETest(shouldAddMessage: false)
+                break
+            }
         }
     }
 
@@ -739,6 +779,170 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+}
+
+// MARK: - Local SSE Demo Server
+
+private final class LocalSSEDemoServer {
+    var onReady: ((URL) -> Void)?
+    var onError: ((Error) -> Void)?
+
+    private let maxEvents: Int
+    private let eventInterval: TimeInterval
+    private let queue = DispatchQueue(label: "com.proxyman.atlantis.example.sse-server")
+    private let listener: NWListener
+    private var connections: [NWConnection] = []
+    private var isStopped = false
+
+    init(maxEvents: Int, eventInterval: TimeInterval) throws {
+        self.maxEvents = maxEvents
+        self.eventInterval = eventInterval
+        self.listener = try NWListener(using: .tcp, on: .any)
+
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.handle(connection)
+        }
+
+        listener.stateUpdateHandler = { [weak self] state in
+            self?.handleListenerState(state)
+        }
+    }
+
+    func start() {
+        listener.start(queue: queue)
+    }
+
+    func stop() {
+        queue.async {
+            self.isStopped = true
+            self.listener.cancel()
+            self.connections.forEach { $0.cancel() }
+            self.connections.removeAll()
+        }
+    }
+
+    private func handleListenerState(_ state: NWListener.State) {
+        switch state {
+        case .ready:
+            guard let port = listener.port,
+                  let url = URL(string: "http://127.0.0.1:\(port.rawValue)/sse-demo") else {
+                return
+            }
+            DispatchQueue.main.async {
+                self.onReady?(url)
+            }
+        case .failed(let error):
+            DispatchQueue.main.async {
+                self.onError?(error)
+            }
+        default:
+            break
+        }
+    }
+
+    private func handle(_ connection: NWConnection) {
+        connections.append(connection)
+        connection.stateUpdateHandler = { [weak self, weak connection] state in
+            guard let self, let connection else { return }
+            if case .cancelled = state {
+                self.connections.removeAll { $0 === connection }
+            }
+        }
+
+        connection.start(queue: queue)
+        readRequest(on: connection, buffer: Data())
+    }
+
+    private func readRequest(on connection: NWConnection, buffer: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 4096) { [weak self] data, _, _, error in
+            guard let self, !self.isStopped else { return }
+            if let error {
+                DispatchQueue.main.async {
+                    self.onError?(error)
+                }
+                connection.cancel()
+                return
+            }
+
+            var requestData = buffer
+            if let data {
+                requestData.append(data)
+            }
+
+            // Wait for the HTTP header terminator before writing the SSE response.
+            if requestData.range(of: Data("\r\n\r\n".utf8)) != nil ||
+                requestData.range(of: Data("\n\n".utf8)) != nil {
+                self.sendResponseHeaders(on: connection)
+            } else {
+                self.readRequest(on: connection, buffer: requestData)
+            }
+        }
+    }
+
+    private func sendResponseHeaders(on connection: NWConnection) {
+        let headers = """
+        HTTP/1.1 200 OK\r
+        Content-Type: text/event-stream; charset=utf-8\r
+        Cache-Control: no-cache, no-transform\r
+        Connection: close\r
+        X-Accel-Buffering: no\r
+        \r
+
+        """
+
+        connection.send(content: Data(headers.utf8), completion: .contentProcessed { [weak self] error in
+            guard let self else { return }
+            if let error {
+                DispatchQueue.main.async {
+                    self.onError?(error)
+                }
+                connection.cancel()
+                return
+            }
+            self.sendEvent(1, on: connection)
+        })
+    }
+
+    private func sendEvent(_ index: Int, on connection: NWConnection) {
+        guard !isStopped else { return }
+        guard index <= maxEvents else {
+            connection.cancel()
+            return
+        }
+
+        queue.asyncAfter(deadline: .now() + eventInterval) { [weak self] in
+            guard let self, !self.isStopped else { return }
+
+            let event = self.makeEvent(index)
+            connection.send(content: Data(event.utf8), completion: .contentProcessed { [weak self] error in
+                guard let self else { return }
+                if let error {
+                    DispatchQueue.main.async {
+                        self.onError?(error)
+                    }
+                    connection.cancel()
+                    return
+                }
+
+                if index >= self.maxEvents {
+                    connection.cancel()
+                } else {
+                    self.sendEvent(index + 1, on: connection)
+                }
+            })
+        }
+    }
+
+    private func makeEvent(_ index: Int) -> String {
+        let payload: [String: Any] = [
+            "index": index,
+            "message": "Atlantis SSE demo event \(index)",
+            "timestamp": Date().timeIntervalSince1970
+        ]
+        let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        let json = data.flatMap { String(data: $0, encoding: .utf8) } ?? #"{"message":"Atlantis SSE demo event"}"#
+        return "event: atlantis-demo\nid: \(index)\ndata: \(json)\n\n"
+    }
 }
 
 // MARK: - SSE URLSession Delegate

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             name: "AtlantisTests",
             dependencies: ["Atlantis"],
             path: "Tests/atlantisTests",
-            resources: [.copy("Resources")])
+            resources: [.process("Resources/sse-server.js")])
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,8 @@ let package = Package(
         .testTarget(
             name: "AtlantisTests",
             dependencies: ["Atlantis"],
-            path: "Tests/atlantisTests")
+            path: "Tests/atlantisTests",
+            resources: [.copy("Resources")])
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Sources/Atlantis.swift
+++ b/Sources/Atlantis.swift
@@ -29,6 +29,8 @@ public final class Atlantis: NSObject {
     private(set) var configuration: Configuration = Configuration.default()
     private var packages: [String: TrafficPackage] = [:]
     private lazy var waitingWebsocketPackages: [String: [TrafficPackage]] = [:]
+    private var sentServerSentEventTrafficIds: Set<String> = []
+    private var serverSentEventBuffers: [String: String] = [:]
     private var ignoreProtocols: [AnyClass] = []
     private let queue = DispatchQueue(label: "com.proxyman.atlantis")
     private var ignoredRequestIds: Set<String> = []
@@ -329,6 +331,10 @@ extension Atlantis: InjectorDelegate {
 
             // update the response
             package?.updateResponse(response)
+
+            if let package = package, package.isServerSentEventStream {
+                startSendingServerSentEventTrafficIfNeeded(package)
+            }
         }
     }
 
@@ -336,9 +342,12 @@ extension Atlantis: InjectorDelegate {
         queue.sync {
             guard Atlantis.isEnabled.value else { return }
             let package = getPackage(dataTask)
-            package?.appendResponseData(data)
-            if let package = package, package.isServerSentEventStream {
-                startSendingMessage(package: package)
+            guard let package = package else { return }
+
+            if package.isServerSentEventStream {
+                sendServerSentEventMessages(package: package, data: data)
+            } else {
+                package.appendResponseData(data)
             }
         }
     }
@@ -446,17 +455,20 @@ extension Atlantis {
             // All done
             package.updateDidComplete(error)
 
+            if package.isServerSentEventStream {
+                sendServerSentEventCloseMessage(package: package, error: error)
+                removeCompletedPackage(taskOrConnection: taskOrConnection, package: package)
+                return
+            }
+
             // At this time, the package has all the data
             // It's time to send it
             startSendingMessage(package: package)
 
             // Then remove it from our cache
-            let taskId = PackageIdentifier.getID(taskOrConnection: taskOrConnection)
             switch package.packageType {
             case .http:
-                packages.removeValue(forKey: package.id)
-                // Clean up taskStartTimes for completed HTTP requests
-                taskStartTimes.removeValue(forKey: taskId)
+                removeCompletedPackage(taskOrConnection: taskOrConnection, package: package)
             case .websocket:
                 // Don't remove the WS traffic
                 // Keep it in the packages, so we can send the WS Message
@@ -465,6 +477,7 @@ extension Atlantis {
                 // Sending all waiting WS
                 attemptSendingAllWaitingWSPackages(id: package.id)
                 // Clean up taskStartTimes for completed WebSocket requests
+                let taskId = PackageIdentifier.getID(taskOrConnection: taskOrConnection)
                 taskStartTimes.removeValue(forKey: taskId)
                 break
             }
@@ -527,6 +540,93 @@ extension Atlantis {
 
         // Release the list
         waitingWebsocketPackages[id] = nil
+    }
+
+    private func removeCompletedPackage(taskOrConnection: AnyObject, package: TrafficPackage) {
+        let taskId = PackageIdentifier.getID(taskOrConnection: taskOrConnection)
+        packages.removeValue(forKey: package.id)
+        taskStartTimes.removeValue(forKey: taskId)
+        sentServerSentEventTrafficIds.remove(package.id)
+        serverSentEventBuffers.removeValue(forKey: package.id)
+    }
+}
+
+// MARK: - Server-Sent Events
+
+extension Atlantis {
+
+    private func startSendingServerSentEventTrafficIfNeeded(_ package: TrafficPackage) {
+        guard !sentServerSentEventTrafficIds.contains(package.id) else {
+            return
+        }
+        sentServerSentEventTrafficIds.insert(package.id)
+        package.markAsWebsocketPackage()
+        startSendingMessage(package: package)
+    }
+
+    private func sendServerSentEventMessages(package: TrafficPackage, data: Data) {
+        startSendingServerSentEventTrafficIfNeeded(package)
+
+        for eventText in parseServerSentEventBlocks(packageId: package.id, data: data) {
+            sendServerSentEventMessage(package: package, eventText: eventText)
+        }
+    }
+
+    private func sendServerSentEventMessage(package: TrafficPackage, eventText: String) {
+        let normalizedEventText = eventText
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+
+        // Reuse Proxyman's streaming-message channel so each SSE event is appended
+        // to the original request instead of creating another traffic row.
+        let streamMessage = WebsocketMessagePackage(id: package.id,
+                                                    message: .string(normalizedEventText),
+                                                    messageType: .receive)
+        package.setWebsocketMessagePackage(package: streamMessage)
+        startSendingWebsocketMessage(package)
+    }
+
+    private func sendServerSentEventCloseMessage(package: TrafficPackage, error: Error?) {
+        guard sentServerSentEventTrafficIds.contains(package.id) else {
+            return
+        }
+
+        if let pendingEvent = serverSentEventBuffers[package.id]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !pendingEvent.isEmpty {
+            sendServerSentEventMessage(package: package, eventText: pendingEvent)
+        }
+
+        let reason = error?.localizedDescription.data(using: .utf8)
+        let closeMessage = WebsocketMessagePackage(id: package.id,
+                                                   closeCode: URLSessionWebSocketTask.CloseCode.normalClosure.rawValue,
+                                                   reason: reason)
+        package.setWebsocketMessagePackage(package: closeMessage)
+        startSendingWebsocketMessage(package)
+    }
+
+    private func parseServerSentEventBlocks(packageId: String, data: Data) -> [String] {
+        let chunk = String(decoding: data, as: UTF8.self)
+        var buffer = (serverSentEventBuffers[packageId] ?? "") + chunk
+        var events: [String] = []
+
+        while let delimiterRange = firstServerSentEventDelimiterRange(in: buffer) {
+            let eventText = String(buffer[..<delimiterRange.lowerBound])
+            buffer.removeSubrange(buffer.startIndex..<delimiterRange.upperBound)
+
+            if !eventText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                events.append(eventText)
+            }
+        }
+
+        serverSentEventBuffers[packageId] = buffer
+        return events
+    }
+
+    private func firstServerSentEventDelimiterRange(in text: String) -> Range<String.Index>? {
+        let delimiters = ["\r\n\r\n", "\n\n", "\r\r"]
+        return delimiters
+            .compactMap { text.range(of: $0) }
+            .min { $0.lowerBound < $1.lowerBound }
     }
 }
 

--- a/Sources/Atlantis.swift
+++ b/Sources/Atlantis.swift
@@ -337,6 +337,9 @@ extension Atlantis: InjectorDelegate {
             guard Atlantis.isEnabled.value else { return }
             let package = getPackage(dataTask)
             package?.appendResponseData(data)
+            if let package = package, package.isServerSentEventStream {
+                startSendingMessage(package: package)
+            }
         }
     }
 

--- a/Sources/Packages.swift
+++ b/Sources/Packages.swift
@@ -64,7 +64,7 @@ public final class TrafficPackage: Codable, CustomDebugStringConvertible, Serial
     public private(set) var responseBodyData: Data
     public private(set) var endAt: TimeInterval?
     public private(set) var lastData: Data?
-    public let packageType: PackageType
+    public private(set) var packageType: PackageType
     private(set) var websocketMessagePackage: WebsocketMessagePackage?
 
     // MARK: - Variables
@@ -84,7 +84,6 @@ public final class TrafficPackage: Codable, CustomDebugStringConvertible, Serial
     }
 
     var isServerSentEventStream: Bool {
-        guard packageType == .http else { return false }
         return response?.isServerSentEventStream == true
     }
 
@@ -224,6 +223,10 @@ public final class TrafficPackage: Codable, CustomDebugStringConvertible, Serial
 
     func setWebsocketMessagePackage(package: WebsocketMessagePackage) {
         self.websocketMessagePackage = package
+    }
+
+    func markAsWebsocketPackage() {
+        self.packageType = .websocket
     }
 }
 

--- a/Sources/Packages.swift
+++ b/Sources/Packages.swift
@@ -83,6 +83,11 @@ public final class TrafficPackage: Codable, CustomDebugStringConvertible, Serial
         return false
     }
 
+    var isServerSentEventStream: Bool {
+        guard packageType == .http else { return false }
+        return response?.isServerSentEventStream == true
+    }
+
     // MARK: - Init
 
     init(id: String,
@@ -177,24 +182,36 @@ public final class TrafficPackage: Codable, CustomDebugStringConvertible, Serial
     }
 
     func toData() -> Data? {
-        // Set nil to prevent being encode to JSON
-        // It might increase the size of the message
-        lastData = nil
+        let request: Request
+        if isLargeRequestBody {
+            request = Request(url: self.request.url, method: self.request.method, headers: self.request.headers, body: nil)
+        } else {
+            request = self.request
+        }
 
         // For some reason, JSONEncoder could not allocate enough RAM to encode a large body
         // It crashes the app if the body might be > 100Mb
-        // We decice to skip the body, but send the request/response
+        // We decide to skip the body, but send the request/response
         // https://github.com/ProxymanApp/atlantis/issues/57
+        let responseBodyData: Data
         if isLargeReponseBody {
-            self.responseBodyData = "<Skip Large Body>".data(using: String.Encoding.utf8)!
-        }
-        if isLargeRequestBody {
-            self.request.resetBody()
+            responseBodyData = "<Skip Large Body>".data(using: String.Encoding.utf8)!
+        } else {
+            responseBodyData = self.responseBodyData
         }
 
         // Encode to JSON
         do {
-            return try JSONEncoder().encode(self)
+            let snapshot = TrafficPackageSnapshot(id: id,
+                                                  startAt: startAt,
+                                                  request: request,
+                                                  response: response,
+                                                  error: error,
+                                                  responseBodyData: responseBodyData,
+                                                  endAt: endAt,
+                                                  packageType: packageType,
+                                                  websocketMessagePackage: websocketMessagePackage)
+            return try JSONEncoder().encode(snapshot)
         } catch let error {
             print(error)
         }
@@ -208,6 +225,18 @@ public final class TrafficPackage: Codable, CustomDebugStringConvertible, Serial
     func setWebsocketMessagePackage(package: WebsocketMessagePackage) {
         self.websocketMessagePackage = package
     }
+}
+
+private struct TrafficPackageSnapshot: Encodable {
+    let id: String
+    let startAt: TimeInterval
+    let request: Request
+    let response: Response?
+    let error: CustomError?
+    let responseBodyData: Data
+    let endAt: TimeInterval?
+    let packageType: TrafficPackage.PackageType
+    let websocketMessagePackage: WebsocketMessagePackage?
 }
 
 struct Device: Codable {
@@ -372,6 +401,13 @@ public struct Response: Codable {
     public init(statusCode: Int, headers: [Header]) {
         self.statusCode = statusCode
         self.headers = headers
+    }
+
+    var isServerSentEventStream: Bool {
+        headers.contains { header in
+            header.key.caseInsensitiveCompare("Content-Type") == .orderedSame &&
+            header.value.range(of: "text/event-stream", options: .caseInsensitive) != nil
+        }
     }
 
     init?(_ response: URLResponse) {

--- a/Tests/atlantisTests/Resources/sse-server.js
+++ b/Tests/atlantisTests/Resources/sse-server.js
@@ -41,6 +41,12 @@ const server = http.createServer((req, res) => {
         [50, "event: update\nid: comment-1\ndata: after-comment\n\n"]
       ]);
       break;
+    case "/split-event":
+      sendSSE(res, [
+        [0, "event: split\nid: split-1\ndata: first"],
+        [50, " line\ndata: second line\n\n"]
+      ]);
+      break;
     default:
       res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
       res.end("Not Found");

--- a/Tests/atlantisTests/Resources/sse-server.js
+++ b/Tests/atlantisTests/Resources/sse-server.js
@@ -1,0 +1,65 @@
+const http = require("http");
+
+function sendSSE(res, chunks) {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream; charset=utf-8",
+    "Cache-Control": "no-cache, no-transform",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no"
+  });
+  res.flushHeaders();
+
+  const timers = chunks.map(([delay, body]) => {
+    return setTimeout(() => {
+      if (!res.destroyed) {
+        res.write(body);
+      }
+    }, delay);
+  });
+
+  res.on("close", () => {
+    timers.forEach(clearTimeout);
+  });
+}
+
+const server = http.createServer((req, res) => {
+  switch (req.url) {
+    case "/basic":
+      sendSSE(res, [
+        [0, "event: greeting\nid: basic-1\ndata: hello-atlantis\n\n"],
+        [50, "event: greeting\nid: basic-2\ndata: goodbye-atlantis\n\n"]
+      ]);
+      break;
+    case "/multiline":
+      sendSSE(res, [
+        [0, "event: note\nid: multiline-1\ndata: first line\ndata: second line\n\n"]
+      ]);
+      break;
+    case "/comment-retry":
+      sendSSE(res, [
+        [0, ": keep-alive\nretry: 1500\n\n"],
+        [50, "event: update\nid: comment-1\ndata: after-comment\n\n"]
+      ]);
+      break;
+    default:
+      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Not Found");
+  }
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const address = server.address();
+  process.stdout.write(`PORT ${address.port}\n`);
+});
+
+function shutdown() {
+  server.close(() => {
+    process.exit(0);
+  });
+  setTimeout(() => {
+    process.exit(0);
+  }, 100).unref();
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/Tests/atlantisTests/atlantisTests.swift
+++ b/Tests/atlantisTests/atlantisTests.swift
@@ -44,6 +44,124 @@ private final class TestTransporter: Transporter {
     }
 }
 
+private enum LocalSSEServerError: Error, CustomStringConvertible {
+    case missingResource
+    case invalidPort(String)
+    case timedOut(String, String)
+
+    var description: String {
+        switch self {
+        case .missingResource:
+            return "Could not find sse-server.js test resource"
+        case .invalidPort(let output):
+            return "Could not parse SSE server port from stdout: \(output)"
+        case .timedOut(let stdout, let stderr):
+            return "Timed out waiting for SSE server. stdout: \(stdout), stderr: \(stderr)"
+        }
+    }
+}
+
+private final class LocalSSEServer {
+    private let process: Process
+    private let stdout: Pipe
+    private let stderr: Pipe
+    private let port: Int
+
+    private init(process: Process, stdout: Pipe, stderr: Pipe, port: Int) {
+        self.process = process
+        self.stdout = stdout
+        self.stderr = stderr
+        self.port = port
+    }
+
+    static func start() throws -> LocalSSEServer {
+        guard let scriptURL = Bundle.module.url(forResource: "sse-server", withExtension: "js") else {
+            throw LocalSSEServerError.missingResource
+        }
+
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let outputQueue = DispatchQueue(label: "com.proxyman.atlantis.tests.sse-server-output")
+        let ready = DispatchSemaphore(value: 0)
+        var stdoutText = ""
+        var stderrText = ""
+        var parsedPort: Int?
+
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["node", scriptURL.path]
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        stdout.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
+            outputQueue.sync {
+                stdoutText += text
+                if parsedPort == nil, let port = parsePort(from: stdoutText) {
+                    parsedPort = port
+                    ready.signal()
+                }
+            }
+        }
+
+        stderr.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
+            outputQueue.sync {
+                stderrText += text
+            }
+        }
+
+        try process.run()
+
+        guard ready.wait(timeout: .now() + 5) == .success else {
+            let output = outputQueue.sync { (stdoutText, stderrText) }
+            stdout.fileHandleForReading.readabilityHandler = nil
+            stderr.fileHandleForReading.readabilityHandler = nil
+            if process.isRunning {
+                process.terminate()
+            }
+            throw LocalSSEServerError.timedOut(output.0, output.1)
+        }
+
+        guard let port = outputQueue.sync(execute: { parsedPort }) else {
+            stdout.fileHandleForReading.readabilityHandler = nil
+            stderr.fileHandleForReading.readabilityHandler = nil
+            if process.isRunning {
+                process.terminate()
+            }
+            throw LocalSSEServerError.invalidPort(outputQueue.sync { stdoutText })
+        }
+
+        return LocalSSEServer(process: process, stdout: stdout, stderr: stderr, port: port)
+    }
+
+    func url(path: String) -> URL {
+        URL(string: "http://127.0.0.1:\(port)\(path)")!
+    }
+
+    func stop() {
+        stdout.fileHandleForReading.readabilityHandler = nil
+        stderr.fileHandleForReading.readabilityHandler = nil
+        if process.isRunning {
+            process.terminate()
+            process.waitUntilExit()
+        }
+    }
+
+    deinit {
+        stop()
+    }
+}
+
+private func parsePort(from text: String) -> Int? {
+    text.split(whereSeparator: \.isNewline).compactMap { line -> Int? in
+        guard line.hasPrefix("PORT ") else { return nil }
+        return Int(line.dropFirst("PORT ".count))
+    }.first
+}
+
 final class URLSessionSwizzleTests: XCTestCase {
     private let baseURL = URL(string: "https://httpbin.proxyman.app")!
     private var transporter: TestTransporter!
@@ -240,11 +358,143 @@ final class URLSessionSwizzleTests: XCTestCase {
         XCTAssertEqual(package.request.body, body)
     }
 
+    func testServerSentEventsBasicStreamCapturedBeforeCompletion() throws {
+        let server = try LocalSSEServer.start()
+        defer { server.stop() }
+
+        var session: URLSession?
+        var task: URLSessionDataTask?
+        defer {
+            task?.cancel()
+            session?.invalidateAndCancel()
+        }
+
+        let package = waitForTrafficPackageIfAvailable(matching: { package in
+            self.isPackageForPath(package, "/basic") &&
+            package.endAt == nil &&
+            self.responseBodyString(package).contains("data: goodbye-atlantis")
+        }, timeout: 10) {
+            session = makeSession()
+            var request = URLRequest(url: server.url(path: "/basic"))
+            request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+            task = session?.dataTask(with: request)
+            task?.resume()
+        }
+
+        guard let package else {
+            XCTFail("Atlantis did not emit an SSE package before the stream completed")
+            return
+        }
+
+        assertServerSentEventPackage(package)
+        let body = responseBodyString(package)
+        XCTAssertTrue(body.contains("event: greeting"))
+        XCTAssertTrue(body.contains("id: basic-1"))
+        XCTAssertTrue(body.contains("data: hello-atlantis"))
+        XCTAssertTrue(body.contains("id: basic-2"))
+        XCTAssertTrue(body.contains("data: goodbye-atlantis"))
+    }
+
+    func testServerSentEventsMultilineEventCapturedBeforeCompletion() throws {
+        let server = try LocalSSEServer.start()
+        defer { server.stop() }
+
+        var session: URLSession?
+        var task: URLSessionDataTask?
+        defer {
+            task?.cancel()
+            session?.invalidateAndCancel()
+        }
+
+        let package = waitForTrafficPackageIfAvailable(matching: { package in
+            self.isPackageForPath(package, "/multiline") &&
+            package.endAt == nil &&
+            self.responseBodyString(package).contains("data: second line")
+        }, timeout: 10) {
+            session = makeSession()
+            var request = URLRequest(url: server.url(path: "/multiline"))
+            request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+            task = session?.dataTask(with: request)
+            task?.resume()
+        }
+
+        guard let package else {
+            XCTFail("Atlantis did not emit a multiline SSE package before the stream completed")
+            return
+        }
+
+        assertServerSentEventPackage(package)
+        let body = responseBodyString(package)
+        XCTAssertTrue(body.contains("event: note"))
+        XCTAssertTrue(body.contains("id: multiline-1"))
+        XCTAssertTrue(body.contains("data: first line"))
+        XCTAssertTrue(body.contains("data: second line"))
+    }
+
+    func testServerSentEventsCommentAndRetryCapturedBeforeCompletion() throws {
+        let server = try LocalSSEServer.start()
+        defer { server.stop() }
+
+        var session: URLSession?
+        var task: URLSessionDataTask?
+        defer {
+            task?.cancel()
+            session?.invalidateAndCancel()
+        }
+
+        let package = waitForTrafficPackageIfAvailable(matching: { package in
+            self.isPackageForPath(package, "/comment-retry") &&
+            package.endAt == nil &&
+            self.responseBodyString(package).contains("data: after-comment")
+        }, timeout: 10) {
+            session = makeSession()
+            var request = URLRequest(url: server.url(path: "/comment-retry"))
+            request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+            task = session?.dataTask(with: request)
+            task?.resume()
+        }
+
+        guard let package else {
+            XCTFail("Atlantis did not emit a comment/retry SSE package before the stream completed")
+            return
+        }
+
+        assertServerSentEventPackage(package)
+        let body = responseBodyString(package)
+        XCTAssertTrue(body.contains(": keep-alive"))
+        XCTAssertTrue(body.contains("retry: 1500"))
+        XCTAssertTrue(body.contains("event: update"))
+        XCTAssertTrue(body.contains("data: after-comment"))
+    }
+
     private func makeSession() -> URLSession {
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = 15
         config.timeoutIntervalForResource = 30
         return URLSession(configuration: config)
+    }
+
+    private func waitForTrafficPackageIfAvailable(matching predicate: @escaping (TrafficPackage) -> Bool,
+                                                  timeout: TimeInterval,
+                                                  action: () -> Void) -> TrafficPackage? {
+        let expectation = expectation(description: "Wait for traffic package")
+        let lock = NSLock()
+        var capturedPackage: TrafficPackage?
+        var didFulfill = false
+
+        transporter.onTrafficPackage = { package in
+            guard predicate(package) else { return }
+            lock.lock()
+            defer { lock.unlock() }
+            guard !didFulfill else { return }
+            didFulfill = true
+            capturedPackage = package
+            expectation.fulfill()
+        }
+
+        action()
+        wait(for: [expectation], timeout: timeout)
+        return capturedPackage
     }
 
     private func waitForTrafficPackage(matching predicate: @escaping (TrafficPackage) -> Bool,
@@ -265,6 +515,25 @@ final class URLSessionSwizzleTests: XCTestCase {
                                                  file: StaticString = #filePath,
                                                  line: UInt = #line) {
         XCTAssertEqual(package.response?.statusCode, 200, file: file, line: line)
+    }
+
+    private func assertServerSentEventPackage(_ package: TrafficPackage,
+                                              file: StaticString = #filePath,
+                                              line: UInt = #line) {
+        XCTAssertEqual(package.response?.statusCode, 200, file: file, line: line)
+        XCTAssertNil(package.endAt, "SSE package should be emitted while the stream is still open", file: file, line: line)
+        XCTAssertTrue(package.response?.headers.contains { header in
+            header.key.caseInsensitiveCompare("Content-Type") == .orderedSame &&
+            header.value.range(of: "text/event-stream", options: .caseInsensitive) != nil
+        } == true, "Expected text/event-stream response", file: file, line: line)
+    }
+
+    private func responseBodyString(_ package: TrafficPackage) -> String {
+        String(data: package.responseBodyData, encoding: .utf8) ?? ""
+    }
+
+    private func isPackageForPath(_ package: TrafficPackage, _ path: String) -> Bool {
+        package.request.method == "GET" && package.request.url.contains(path)
     }
 
     private func assertSelectorExists(baseClass: AnyClass,

--- a/Tests/atlantisTests/atlantisTests.swift
+++ b/Tests/atlantisTests/atlantisTests.swift
@@ -10,9 +10,33 @@ private struct TestMessageEnvelope: Codable {
     let buildVersion: String?
 }
 
+private struct TestStreamPackageContent: Codable {
+    let id: String
+    let request: TestRequestContent
+    let websocketMessagePackage: TestStreamMessagePackage?
+}
+
+private struct TestRequestContent: Codable {
+    let url: String
+    let method: String
+}
+
+private struct TestStreamMessagePackage: Codable {
+    let id: String
+    let messageType: WebsocketMessagePackage.MessageType
+    let stringValue: String?
+    let dataValue: Data?
+}
+
+private struct TestServerSentEventCapture {
+    let trafficPackages: [TrafficPackage]
+    let streamMessages: [TestStreamMessagePackage]
+}
+
 private final class TestTransporter: Transporter {
     private let queue = DispatchQueue(label: "com.proxyman.atlantis.tests.transporter")
     private var messages: [TestMessageEnvelope] = []
+    var onMessageEnvelope: ((TestMessageEnvelope) -> Void)?
     var onTrafficPackage: ((TrafficPackage) -> Void)?
 
     func start(_ config: Configuration) {
@@ -31,6 +55,7 @@ private final class TestTransporter: Transporter {
         queue.async {
             self.messages.append(envelope)
         }
+        onMessageEnvelope?(envelope)
         guard envelope.messageType == .traffic,
               let content = envelope.content,
               let traffic = try? JSONDecoder().decode(TrafficPackage.self, from: content) else {
@@ -44,6 +69,7 @@ private final class TestTransporter: Transporter {
     }
 }
 
+#if os(macOS)
 private enum LocalSSEServerError: Error, CustomStringConvertible {
     case missingResource
     case invalidPort(String)
@@ -75,7 +101,12 @@ private final class LocalSSEServer {
     }
 
     static func start() throws -> LocalSSEServer {
-        guard let scriptURL = Bundle.module.url(forResource: "sse-server", withExtension: "js") else {
+        let resourceCandidates = [
+            Bundle.module.bundleURL.appendingPathComponent("sse-server.js"),
+            Bundle.module.resourceURL?.appendingPathComponent("sse-server.js")
+        ].compactMap { $0 }
+
+        guard let scriptURL = resourceCandidates.first(where: { FileManager.default.fileExists(atPath: $0.path) }) else {
             throw LocalSSEServerError.missingResource
         }
 
@@ -161,6 +192,7 @@ private func parsePort(from text: String) -> Int? {
         return Int(line.dropFirst("PORT ".count))
     }.first
 }
+#endif
 
 final class URLSessionSwizzleTests: XCTestCase {
     private let baseURL = URL(string: "https://httpbin.proxyman.app")!
@@ -358,7 +390,8 @@ final class URLSessionSwizzleTests: XCTestCase {
         XCTAssertEqual(package.request.body, body)
     }
 
-    func testServerSentEventsBasicStreamCapturedBeforeCompletion() throws {
+#if os(macOS)
+    func testServerSentEventsBasicStreamUsesSingleTrafficAndStreamMessages() throws {
         let server = try LocalSSEServer.start()
         defer { server.stop() }
 
@@ -369,11 +402,9 @@ final class URLSessionSwizzleTests: XCTestCase {
             session?.invalidateAndCancel()
         }
 
-        let package = waitForTrafficPackageIfAvailable(matching: { package in
-            self.isPackageForPath(package, "/basic") &&
-            package.endAt == nil &&
-            self.responseBodyString(package).contains("data: goodbye-atlantis")
-        }, timeout: 10) {
+        let capture = waitForServerSentEventCapture(path: "/basic",
+                                                    expectedMessageFragments: ["data: hello-atlantis", "data: goodbye-atlantis"],
+                                                    timeout: 10) {
             session = makeSession()
             var request = URLRequest(url: server.url(path: "/basic"))
             request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
@@ -381,21 +412,21 @@ final class URLSessionSwizzleTests: XCTestCase {
             task?.resume()
         }
 
-        guard let package else {
-            XCTFail("Atlantis did not emit an SSE package before the stream completed")
+        XCTAssertEqual(capture.trafficPackages.count, 1, "SSE should create exactly one HTTP traffic row")
+        guard let package = capture.trafficPackages.first else {
+            XCTFail("Atlantis did not emit the initial SSE traffic package")
             return
         }
 
         assertServerSentEventPackage(package)
-        let body = responseBodyString(package)
-        XCTAssertTrue(body.contains("event: greeting"))
-        XCTAssertTrue(body.contains("id: basic-1"))
-        XCTAssertTrue(body.contains("data: hello-atlantis"))
-        XCTAssertTrue(body.contains("id: basic-2"))
-        XCTAssertTrue(body.contains("data: goodbye-atlantis"))
+        XCTAssertTrue(capture.streamMessages.contains { $0.stringValue?.contains("event: greeting") == true })
+        XCTAssertTrue(capture.streamMessages.contains { $0.stringValue?.contains("id: basic-1") == true })
+        XCTAssertTrue(capture.streamMessages.contains { $0.stringValue?.contains("data: hello-atlantis") == true })
+        XCTAssertTrue(capture.streamMessages.contains { $0.stringValue?.contains("id: basic-2") == true })
+        XCTAssertTrue(capture.streamMessages.contains { $0.stringValue?.contains("data: goodbye-atlantis") == true })
     }
 
-    func testServerSentEventsMultilineEventCapturedBeforeCompletion() throws {
+    func testServerSentEventsMultilineEventUsesSingleStreamMessage() throws {
         let server = try LocalSSEServer.start()
         defer { server.stop() }
 
@@ -406,11 +437,9 @@ final class URLSessionSwizzleTests: XCTestCase {
             session?.invalidateAndCancel()
         }
 
-        let package = waitForTrafficPackageIfAvailable(matching: { package in
-            self.isPackageForPath(package, "/multiline") &&
-            package.endAt == nil &&
-            self.responseBodyString(package).contains("data: second line")
-        }, timeout: 10) {
+        let capture = waitForServerSentEventCapture(path: "/multiline",
+                                                    expectedMessageFragments: ["data: first line", "data: second line"],
+                                                    timeout: 10) {
             session = makeSession()
             var request = URLRequest(url: server.url(path: "/multiline"))
             request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
@@ -418,20 +447,21 @@ final class URLSessionSwizzleTests: XCTestCase {
             task?.resume()
         }
 
-        guard let package else {
-            XCTFail("Atlantis did not emit a multiline SSE package before the stream completed")
+        XCTAssertEqual(capture.trafficPackages.count, 1, "SSE should create exactly one HTTP traffic row")
+        guard let package = capture.trafficPackages.first else {
+            XCTFail("Atlantis did not emit the initial multiline SSE traffic package")
             return
         }
 
         assertServerSentEventPackage(package)
-        let body = responseBodyString(package)
-        XCTAssertTrue(body.contains("event: note"))
-        XCTAssertTrue(body.contains("id: multiline-1"))
-        XCTAssertTrue(body.contains("data: first line"))
-        XCTAssertTrue(body.contains("data: second line"))
+        let multilineMessages = capture.streamMessages.filter { $0.stringValue?.contains("id: multiline-1") == true }
+        XCTAssertEqual(multilineMessages.count, 1)
+        XCTAssertTrue(multilineMessages.first?.stringValue?.contains("event: note") == true)
+        XCTAssertTrue(multilineMessages.first?.stringValue?.contains("data: first line") == true)
+        XCTAssertTrue(multilineMessages.first?.stringValue?.contains("data: second line") == true)
     }
 
-    func testServerSentEventsCommentAndRetryCapturedBeforeCompletion() throws {
+    func testServerSentEventsCommentAndRetryUseStreamMessages() throws {
         let server = try LocalSSEServer.start()
         defer { server.stop() }
 
@@ -442,11 +472,9 @@ final class URLSessionSwizzleTests: XCTestCase {
             session?.invalidateAndCancel()
         }
 
-        let package = waitForTrafficPackageIfAvailable(matching: { package in
-            self.isPackageForPath(package, "/comment-retry") &&
-            package.endAt == nil &&
-            self.responseBodyString(package).contains("data: after-comment")
-        }, timeout: 10) {
+        let capture = waitForServerSentEventCapture(path: "/comment-retry",
+                                                    expectedMessageFragments: [": keep-alive", "retry: 1500", "data: after-comment"],
+                                                    timeout: 10) {
             session = makeSession()
             var request = URLRequest(url: server.url(path: "/comment-retry"))
             request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
@@ -454,24 +482,113 @@ final class URLSessionSwizzleTests: XCTestCase {
             task?.resume()
         }
 
-        guard let package else {
-            XCTFail("Atlantis did not emit a comment/retry SSE package before the stream completed")
+        XCTAssertEqual(capture.trafficPackages.count, 1, "SSE should create exactly one HTTP traffic row")
+        guard let package = capture.trafficPackages.first else {
+            XCTFail("Atlantis did not emit the initial comment/retry SSE traffic package")
             return
         }
 
         assertServerSentEventPackage(package)
-        let body = responseBodyString(package)
-        XCTAssertTrue(body.contains(": keep-alive"))
-        XCTAssertTrue(body.contains("retry: 1500"))
-        XCTAssertTrue(body.contains("event: update"))
-        XCTAssertTrue(body.contains("data: after-comment"))
+        XCTAssertTrue(capture.streamMessages.contains { $0.stringValue?.contains(": keep-alive") == true })
+        XCTAssertTrue(capture.streamMessages.contains { $0.stringValue?.contains("retry: 1500") == true })
+        XCTAssertTrue(capture.streamMessages.contains { $0.stringValue?.contains("event: update") == true })
+        XCTAssertTrue(capture.streamMessages.contains { $0.stringValue?.contains("data: after-comment") == true })
     }
+
+    func testServerSentEventsSplitAcrossChunksWaitForCompleteEvent() throws {
+        let server = try LocalSSEServer.start()
+        defer { server.stop() }
+
+        var session: URLSession?
+        var task: URLSessionDataTask?
+        defer {
+            task?.cancel()
+            session?.invalidateAndCancel()
+        }
+
+        let capture = waitForServerSentEventCapture(path: "/split-event",
+                                                    expectedMessageFragments: ["data: first line", "data: second line"],
+                                                    timeout: 10) {
+            session = makeSession()
+            var request = URLRequest(url: server.url(path: "/split-event"))
+            request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+            task = session?.dataTask(with: request)
+            task?.resume()
+        }
+
+        XCTAssertEqual(capture.trafficPackages.count, 1, "SSE should create exactly one HTTP traffic row")
+        guard let package = capture.trafficPackages.first else {
+            XCTFail("Atlantis did not emit the initial split SSE traffic package")
+            return
+        }
+
+        assertServerSentEventPackage(package)
+        let splitMessages = capture.streamMessages.filter { $0.stringValue?.contains("id: split-1") == true }
+        XCTAssertEqual(splitMessages.count, 1)
+        XCTAssertTrue(splitMessages.first?.stringValue?.contains("event: split") == true)
+        XCTAssertTrue(splitMessages.first?.stringValue?.contains("data: first line") == true)
+        XCTAssertTrue(splitMessages.first?.stringValue?.contains("data: second line") == true)
+    }
+#endif
 
     private func makeSession() -> URLSession {
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = 15
         config.timeoutIntervalForResource = 30
         return URLSession(configuration: config)
+    }
+
+    private func waitForServerSentEventCapture(path: String,
+                                               expectedMessageFragments: [String],
+                                               timeout: TimeInterval,
+                                               action: () -> Void) -> TestServerSentEventCapture {
+        let expectation = expectation(description: "Wait for SSE stream messages")
+        let lock = NSLock()
+        var trafficPackages: [TrafficPackage] = []
+        var streamMessages: [TestStreamMessagePackage] = []
+        var didFulfill = false
+
+        transporter.onMessageEnvelope = { envelope in
+            lock.lock()
+            defer { lock.unlock() }
+
+            switch envelope.messageType {
+            case .traffic:
+                guard let content = envelope.content,
+                      let package = try? JSONDecoder().decode(TrafficPackage.self, from: content),
+                      self.isPackageForPath(package, path) else {
+                    return
+                }
+                trafficPackages.append(package)
+            case .websocket:
+                guard let content = envelope.content,
+                      let package = try? JSONDecoder().decode(TestStreamPackageContent.self, from: content),
+                      package.request.url.contains(path),
+                      let streamMessage = package.websocketMessagePackage else {
+                    return
+                }
+                streamMessages.append(streamMessage)
+            case .connection:
+                return
+            }
+
+            let hasExpectedMessages = expectedMessageFragments.allSatisfy { fragment in
+                streamMessages.contains { $0.stringValue?.contains(fragment) == true }
+            }
+            if !didFulfill, !trafficPackages.isEmpty, hasExpectedMessages {
+                didFulfill = true
+                expectation.fulfill()
+            }
+        }
+
+        action()
+        wait(for: [expectation], timeout: timeout)
+        transporter.onMessageEnvelope = nil
+
+        lock.lock()
+        defer { lock.unlock() }
+        return TestServerSentEventCapture(trafficPackages: trafficPackages,
+                                          streamMessages: streamMessages)
     }
 
     private func waitForTrafficPackageIfAvailable(matching predicate: @escaping (TrafficPackage) -> Bool,
@@ -520,6 +637,7 @@ final class URLSessionSwizzleTests: XCTestCase {
     private func assertServerSentEventPackage(_ package: TrafficPackage,
                                               file: StaticString = #filePath,
                                               line: UInt = #line) {
+        XCTAssertEqual(package.packageType, .websocket, "SSE traffic must use the existing WebSocket-compatible package type so older Proxyman versions append events to one flow", file: file, line: line)
         XCTAssertEqual(package.response?.statusCode, 200, file: file, line: line)
         XCTAssertNil(package.endAt, "SSE package should be emitted while the stream is still open", file: file, line: line)
         XCTAssertTrue(package.response?.headers.contains { header in


### PR DESCRIPTION
## Summary
- Add a Node-based SSE fixture server for XCTest and cover basic, multiline, and comment/retry SSE cases.
- Teach Atlantis to recognize `text/event-stream` responses and emit traffic updates while the stream is still open.
- Make `TrafficPackage` serialization snapshot-based so repeated SSE updates do not mutate live package state.
- Extend the SwiftUI example with a dedicated SSE demo section for live capture verification.

## Testing
- `swift test` passes with the new SSE coverage and existing URLSession swizzle tests.
- Validated the SwiftUI demo file with iOS simulator type-checking.
- Attempted an Xcode app build, but the example scheme is blocked in this environment by the embedded Watch app/watchOS runtime requirement.